### PR TITLE
api_test: fix interfaces comparison failure

### DIFF
--- a/examples/api_test.py
+++ b/examples/api_test.py
@@ -106,7 +106,12 @@ assert(container.state == "RUNNING")
 
 ## Checking IP address
 print("Getting the interface names")
-assert(set(container.get_interfaces()) == set(('lo', 'eth0')))
+expected_ifs = set(('lo', 'eth0'))
+if os.path.isdir('/sys/module/sit'):
+    expected_ifs.add('sit0')
+if os.path.isdir('/sys/module/ipip'):
+    expected_ifs.add('tunl0')
+assert(set(container.get_interfaces()) == expected_ifs)
 
 ## Checking IP address
 print("Getting the IP addresses")


### PR DESCRIPTION
When the host has kernel module sit or ipip inserted, additional network interfaces sit0 and/or tunl0 would appear inside the container by default as well, which fails the api_test.

This change append sit0/tunl0 to expected interfaces when applicable.

Closes: #2
Signed-off-by: You-Sheng Yang <vicamo@gmail.com>