### PR TITLE
Fix ContainerNetworkList throwing KeyError

### DIFF
--- a/lxc/__init__.py
+++ b/lxc/__init__.py
@@ -124,7 +124,10 @@ class ContainerNetworkList():
         return ContainerNetwork(self.container, index)
 
     def __len__(self):
-        values = self.container.get_config_item("lxc.net")
+        try:
+            values = self.container.get_config_item("lxc.net")
+        except KeyError:
+            values = None
 
         if values:
             return len(values)


### PR DESCRIPTION
Just implemented as suggested in the issue, but not sure if this is exactly where we want to catch the error, or if it would be more appropriate somewhere upstream, such as in the `Container` class?