### PR TITLE
Allows setting of multiple network devices at creation.

### DIFF
--- a/lxc/__init__.py
+++ b/lxc/__init__.py
@@ -119,7 +119,8 @@ class ContainerNetworkList():
 
     def __getitem__(self, index):
         if index >= len(self):
-            raise IndexError("list index out of range")
+            # If index of network is out of bounds, create a new network.
+            self.add("temp_type")
 
         return ContainerNetwork(self.container, index)
 


### PR DESCRIPTION
[Work in progress PR]

Fixes [#17 ](https://github.com/lxc/python3-lxc/issues/17)

> Crash when attempting to set multiple network devices using Python bindings during container creation.

Changes:

    `ContainerNetworkList.__getitem__()' will create a new network by calling 'ContainerNetworkList.add()' if the requested index is not in bounds.

Signed-off-by: Michael Satanovsky michael.satanovsky@gmail.com