### PR TITLE
Unlock GIL while creating container

### DIFF
--- a/lxc.c
+++ b/lxc.c
@@ -939,11 +939,13 @@ Container_create(Container *self, PyObject *args, PyObject *kwds)
         }
     }
 
+    Py_BEGIN_ALLOW_THREADS
     if (self->container->create(self->container, template_name, bdevtype, &fs_specs,
                                 flags, create_args))
         retval = Py_True;
     else
         retval = Py_False;
+    Py_END_ALLOW_THREADS
 
     if (vargs) {
         /* We cannot have gotten here unless vargs was given and create_args


### PR DESCRIPTION
Pretty useful if running .create() in a thread, either manually or via asyncio run_in_executor()

I am not 100% sure if it's ok to release the GIL while using Py_{True,False}. It should be fine as Py_INCREF() comes later.
If there are any doubts I could change this to use a temporary return var and have the check after Py_END_ALLOW_THREADS.