### PR TITLE
Add optional fssize argument to create() to make bdevtype=loop work

### DIFF
--- a/lxc.c
+++ b/lxc.c
@@ -916,9 +916,12 @@ Container_create(Container *self, PyObject *args, PyObject *kwds)
     PyObject *vargs = NULL;
     char *bdevtype = NULL;
     int i = 0;
-    static char *kwlist[] = {"template", "flags", "bdevtype", "args", NULL};
-    if (! PyArg_ParseTupleAndKeywords(args, kwds, "|sisO", kwlist,
-                                      &template_name, &flags, &bdevtype, &vargs))
+    struct bdev_specs fs_specs;
+    memset(&fs_specs, 0, sizeof(fs_specs));
+    static char *kwlist[] = {"template", "flags", "bdevtype", "fssize", "args", NULL};
+    if (! PyArg_ParseTupleAndKeywords(args, kwds, "|siskO", kwlist,
+                                      &template_name, &flags, &bdevtype,
+                                      &fs_specs.fssize, &vargs))
         return NULL;
 
     if (vargs) {
@@ -934,7 +937,7 @@ Container_create(Container *self, PyObject *args, PyObject *kwds)
         }
     }
 
-    if (self->container->create(self->container, template_name, bdevtype, NULL,
+    if (self->container->create(self->container, template_name, bdevtype, &fs_specs,
                                 flags, create_args))
         retval = Py_True;
     else
@@ -1724,7 +1727,7 @@ static PyMethodDef Container_methods[] = {
     },
     {"create", (PyCFunction)Container_create,
      METH_VARARGS|METH_KEYWORDS,
-     "create(template, args = (,)) -> boolean\n"
+     "create(template, flags, bdevtype, fssize, args = (,)) -> boolean\n"
      "\n"
      "Create a new rootfs for the container, using the given template "
      "and passing some optional arguments to it."

--- a/lxc/__init__.py
+++ b/lxc/__init__.py
@@ -209,7 +209,7 @@ class Container(_lxc.Container):
 
         return _lxc.Container.set_config_item(self, key, value)
 
-    def create(self, template=None, flags=0, args=(), bdevtype=None):
+    def create(self, template=None, flags=0, args=(), bdevtype=None, fssize=0):
         """
             Create a new rootfs for the container.
 
@@ -235,6 +235,7 @@ class Container(_lxc.Container):
         template_args['args'] = tuple(args)
         if bdevtype:
             template_args['bdevtype'] = bdevtype
+        template_args['fssize'] = fssize
         if not self.defined:
            self.save_config()
         return _lxc.Container.create(self, **template_args)


### PR DESCRIPTION
Add optional fssize argument to create() to make bdevtype=loop (and possibly others) work by falling back to their defaults instead of returning -1 because bdev_specs is NULL.