### PR TITLE
api_test: fix possible infinite loop when trying to get the ip address

### DIFF
--- a/examples/api_test.py
+++ b/examples/api_test.py
@@ -118,7 +118,7 @@ print("Getting the IP addresses")
 
 count = 0
 ips = []
-while not ips or count == 10:
+while not ips and count != 30:
     ips = container.get_ips()
     time.sleep(1)
     count += 1


### PR DESCRIPTION
If the the ips can not be correctly obtained with container.get_ips()
this while loop will never ends.

Fix this by using:
  while not ips and count != 30

So that even if the ips is empty, the loop will get terminated after
30 attempts (30 seconds later). This retry limit was bumped from 10
to 30 to give it a chance to get the ip address.

If the ip address cannot be obtained, this test will failed with:
  Traceback (most recent call last):
    File "/usr/share/doc/python3-lxc/examples/api_test.py", line 131, in <module>
      assert(len(ips) > 0)
  AssertionError

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>