### PR TITLE
Update configuration for examples/api_test.py

### DIFF
--- a/examples/api_test.py
+++ b/examples/api_test.py
@@ -66,7 +66,7 @@ except:
 print("Creating rootfs using 'download', arch=%s" % arch)
 container.create("download", 0,
                  {"dist": "ubuntu",
-                  "release": "xenial",
+                  "release": "noble",
                   "arch": arch})
 
 assert(container.defined)
@@ -141,10 +141,10 @@ assert(container.name == CONTAINER_NAME
 
 ## Testing cgroups a bit
 print("Testing cgroup API")
-max_mem = container.get_cgroup_item("memory.max_usage_in_bytes")
-current_limit = container.get_cgroup_item("memory.limit_in_bytes")
-assert(container.set_cgroup_item("memory.limit_in_bytes", max_mem))
-assert(container.get_cgroup_item("memory.limit_in_bytes") != current_limit)
+max_mem = container.get_cgroup_item("memory.peak")
+current_limit = container.get_cgroup_item("memory.max")
+assert(container.set_cgroup_item("memory.max", max_mem))
+assert(container.get_cgroup_item("memory.max") != current_limit)
 
 ## Freezing the container
 print("Freezing the container")


### PR DESCRIPTION
This example script is guaranteed to fail on modern Ubuntu releases due to outdated configuration. These changes allow the script to pass on at least Noble:

- Fixes container.create arguments to request Noble image instead of Xenial, as Xenial images are no longer available

- Changes cgroups key strings to use cgroups v2 nomenclature (`max` instead of `limit_in_bytes`, `peak` instead of `max_usage_in_bytes`)

---

The Xenial image issue manifests as:

```
Downloading the image index
ERROR: Couldn't find a matching image
```

The cgroups issue (which, admittedly, will only occur on systems running cgroups v2) will manifest as `KeyError: invalid cgroup entry`. I propose this change simply because cgroups v2 is default on modern Ubuntu releases.